### PR TITLE
Implement transcription service backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+transcriptions.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# ambience-ai-audio-transcription
-interview
+# Audio Transcription Service
+
+This project provides a FastAPI-based backend service that accepts transcription jobs, calls a mocked ASR service, and returns job status and transcripts. Jobs and chunk-level progress are persisted in SQLite so the service can resume in-flight work after a restart.
+
+## Features
+
+- Submit jobs with ordered audio chunk URIs via `POST /transcribe`
+- Query job status and transcripts via `GET /transcript/{jobId}`
+- Search jobs by status or user via `GET /transcript/search`
+- Background processing with retry logic for transient ASR failures
+- Concurrency limit enforcement for ASR requests
+- Persistence to resume work after service restarts
+
+## Getting Started
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Run the API server
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The service stores its SQLite database in `transcriptions.db` by default. To use a different path, set the `TRANSCRIPTION_DATABASE_URL` environment variable to a SQLAlchemy-compatible connection string.
+
+### Example Requests
+
+Create a job:
+
+```bash
+curl -X POST http://localhost:8000/transcribe \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "patient-123", "audioChunkPaths": ["segment1", "segment2"]}'
+```
+
+Check job status:
+
+```bash
+curl http://localhost:8000/transcript/<jobId>
+```
+
+Search jobs for a user:
+
+```bash
+curl "http://localhost:8000/transcript/search?userId=patient-123"
+```

--- a/app/asr_client.py
+++ b/app/asr_client.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Iterable, Set
+
+
+class ASRClientError(Exception):
+    """Base class for simulated ASR client errors."""
+
+
+class TransientASRError(ASRClientError):
+    """Raised when the ASR service encounters a transient failure."""
+
+
+class PermanentASRError(ASRClientError):
+    """Raised when the ASR service encounters a permanent failure."""
+
+
+class ASRClient:
+    """Simulated asynchronous ASR client with concurrency and failure characteristics."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrency: int = 100,
+        transient_failure_rate: float = 0.05,
+        permanent_failures: Iterable[str] | None = None,
+        min_latency_seconds: float = 0.1,
+        max_latency_seconds: float = 0.2,
+    ) -> None:
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._transient_failure_rate = transient_failure_rate
+        self._permanent_failures: Set[str] = set(permanent_failures or [])
+        self._min_latency = min_latency_seconds
+        self._max_latency = max_latency_seconds
+
+    async def transcribe(self, audio_path: str) -> str:
+        """Simulate a transcription call with latency and possible failures."""
+        async with self._semaphore:
+            await asyncio.sleep(random.uniform(self._min_latency, self._max_latency))
+            if audio_path in self._permanent_failures:
+                raise PermanentASRError(f"Audio path {audio_path} cannot be transcribed")
+            if random.random() < self._transient_failure_rate:
+                raise TransientASRError("Transient ASR failure")
+            return f"Transcript for {audio_path}"

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
+
+DATABASE_URL = os.getenv("TRANSCRIPTION_DATABASE_URL", "sqlite+aiosqlite:///./transcriptions.db")
+
+engine = create_async_engine(
+    DATABASE_URL,
+    echo=False,
+    future=True,
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    engine,
+    expire_on_commit=False,
+)
+
+Base = declarative_base()
+
+
+async def init_db() -> None:
+    """Create database tables."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import uuid4
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from .asr_client import ASRClient
+from .database import AsyncSessionLocal, init_db
+from .models import AudioChunk, Job, JobStatus
+from .schemas import TranscribeRequest, TranscribeResponse, TranscriptResult, build_transcript_result
+from .worker import JobProcessor
+
+app = FastAPI(title="Audio Transcription Service")
+
+
+asr_client = ASRClient(
+    max_concurrency=100,
+    transient_failure_rate=0.05,
+    permanent_failures={"bad_audio_segment"},
+)
+job_processor = JobProcessor(asr_client)
+
+
+async def get_session():
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db()
+    await job_processor.start()
+    await job_processor.resume_incomplete_jobs()
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    await job_processor.stop()
+
+
+@app.post("/transcribe", response_model=TranscribeResponse, status_code=202)
+async def create_transcription_job(
+    request: TranscribeRequest, session=Depends(get_session)
+) -> TranscribeResponse:
+    job_id = str(uuid4())
+    job = Job(id=job_id, user_id=request.userId, status=JobStatus.QUEUED)
+    session.add(job)
+    for index, audio_path in enumerate(request.audioChunkPaths):
+        chunk = AudioChunk(job_id=job_id, sequence=index, audio_path=audio_path)
+        session.add(chunk)
+    await session.commit()
+    await job_processor.enqueue_job(job_id)
+    return TranscribeResponse(jobId=job_id)
+
+
+@app.get("/transcript/{job_id}", response_model=TranscriptResult)
+async def get_transcript(job_id: str, session=Depends(get_session)) -> TranscriptResult:
+    result = await session.execute(
+        select(Job)
+        .options(selectinload(Job.chunks))
+        .where(Job.id == job_id)
+    )
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return build_transcript_result(job)
+
+
+@app.get("/transcript/search", response_model=List[TranscriptResult])
+async def search_transcripts(
+    jobStatus: Optional[JobStatus] = Query(default=None),
+    userId: Optional[str] = Query(default=None),
+    session=Depends(get_session),
+) -> List[TranscriptResult]:
+    query = select(Job).options(selectinload(Job.chunks))
+    if jobStatus is not None:
+        query = query.where(Job.status == jobStatus)
+    if userId is not None:
+        query = query.where(Job.user_id == userId)
+    result = await session.execute(query.order_by(Job.created_at.desc()))
+    jobs = result.scalars().unique().all()
+    return [build_transcript_result(job) for job in jobs]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class JobStatus(str, enum.Enum):
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ChunkStatus(str, enum.Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    TRANSIENT_ERROR = "transient_error"
+    PERMANENT_FAILURE = "permanent_failure"
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    status: Mapped[JobStatus] = mapped_column(Enum(JobStatus), nullable=False, default=JobStatus.QUEUED)
+    transcript_text: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    chunks: Mapped[List[AudioChunk]] = relationship(
+        back_populates="job", order_by="AudioChunk.sequence", cascade="all, delete-orphan"
+    )
+
+
+class AudioChunk(Base):
+    __tablename__ = "audio_chunks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False, index=True)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    audio_path: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[ChunkStatus] = mapped_column(Enum(ChunkStatus), nullable=False, default=ChunkStatus.PENDING)
+    transcript_text: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    job: Mapped[Job] = relationship(back_populates="chunks")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+from .models import ChunkStatus, Job, JobStatus
+
+
+class TranscribeRequest(BaseModel):
+    audioChunkPaths: List[str] = Field(..., min_items=1)
+    userId: str = Field(..., min_length=1)
+
+    @validator("audioChunkPaths")
+    def validate_paths(cls, value: List[str]) -> List[str]:
+        if any(not path for path in value):
+            raise ValueError("audioChunkPaths must not contain empty values")
+        return value
+
+
+class TranscribeResponse(BaseModel):
+    jobId: str
+
+
+class TranscriptResult(BaseModel):
+    jobId: str
+    userId: str
+    transcriptText: str
+    chunkStatuses: Dict[str, ChunkStatus]
+    jobStatus: JobStatus
+    completedTime: Optional[datetime]
+
+
+def build_transcript_result(job: Job) -> TranscriptResult:
+    ordered_statuses: "OrderedDict[str, ChunkStatus]" = OrderedDict()
+    transcript_parts = []
+    for chunk in sorted(job.chunks, key=lambda c: c.sequence):
+        ordered_statuses[chunk.audio_path] = chunk.status
+        if chunk.transcript_text:
+            transcript_parts.append(chunk.transcript_text)
+    transcript_text = "\n".join(transcript_parts)
+    return TranscriptResult(
+        jobId=job.id,
+        userId=job.user_id,
+        transcriptText=transcript_text,
+        chunkStatuses=dict(ordered_statuses),
+        jobStatus=job.status,
+        completedTime=job.completed_at,
+    )

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import List, Sequence
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import selectinload
+
+from .asr_client import ASRClient, PermanentASRError, TransientASRError
+from .database import AsyncSessionLocal
+from .models import AudioChunk, ChunkStatus, Job, JobStatus
+
+
+class JobProcessor:
+    """Background worker that processes transcription jobs."""
+
+    def __init__(
+        self,
+        asr_client: ASRClient,
+        *,
+        worker_count: int = 4,
+        max_retries: int = 3,
+        retry_backoff_seconds: float = 0.5,
+    ) -> None:
+        self._asr_client = asr_client
+        self._worker_count = worker_count
+        self._max_retries = max_retries
+        self._retry_backoff_seconds = retry_backoff_seconds
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self._pending_jobs: set[str] = set()
+        self._workers: List[asyncio.Task[None]] = []
+        self._shutdown_event = asyncio.Event()
+
+    async def start(self) -> None:
+        self._shutdown_event.clear()
+        for _ in range(self._worker_count):
+            task = asyncio.create_task(self._worker_loop())
+            self._workers.append(task)
+
+    async def stop(self) -> None:
+        self._shutdown_event.set()
+        for task in self._workers:
+            task.cancel()
+        for task in self._workers:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._workers.clear()
+
+    async def enqueue_job(self, job_id: str) -> None:
+        if job_id in self._pending_jobs:
+            return
+        self._pending_jobs.add(job_id)
+        await self._queue.put(job_id)
+
+    async def resume_incomplete_jobs(self) -> None:
+        async with AsyncSessionLocal() as session:
+            await session.execute(
+                update(AudioChunk)
+                .where(AudioChunk.status == ChunkStatus.IN_PROGRESS)
+                .values(status=ChunkStatus.PENDING)
+            )
+            await session.commit()
+            result = await session.execute(
+                select(Job.id).where(Job.status.in_([JobStatus.QUEUED, JobStatus.IN_PROGRESS]))
+            )
+            job_ids = [row[0] for row in result.all()]
+        for job_id in job_ids:
+            await self.enqueue_job(job_id)
+
+    async def _worker_loop(self) -> None:
+        while not self._shutdown_event.is_set():
+            try:
+                job_id = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+            try:
+                await self._process_job(job_id)
+            finally:
+                self._pending_jobs.discard(job_id)
+                self._queue.task_done()
+
+    async def _process_job(self, job_id: str) -> None:
+        chunk_ids = await self._prepare_job(job_id)
+        if not chunk_ids:
+            return
+        job_failed = False
+        for chunk_id in chunk_ids:
+            success = await self._process_chunk(chunk_id)
+            if not success:
+                job_failed = True
+        await self._finalize_job(job_id, job_failed)
+
+    async def _prepare_job(self, job_id: str) -> Sequence[int]:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(Job)
+                .options(selectinload(Job.chunks))
+                .where(Job.id == job_id)
+            )
+            job = result.scalar_one_or_none()
+            if job is None:
+                return []
+            if job.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+                return []
+            job.status = JobStatus.IN_PROGRESS
+            job.updated_at = datetime.utcnow()
+            await session.commit()
+            return [chunk.id for chunk in job.chunks]
+
+    async def _process_chunk(self, chunk_id: int) -> bool:
+        while True:
+            preparation = await self._prepare_chunk(chunk_id)
+            if preparation is None:
+                return False
+            if preparation["state"] == "completed":
+                return True
+            if preparation["state"] == "failed":
+                return False
+            attempt = preparation["attempt"]
+            audio_path = preparation["audio_path"]
+            try:
+                transcript = await self._asr_client.transcribe(audio_path)
+            except TransientASRError as exc:
+                should_retry = await self._handle_transient_failure(chunk_id, str(exc), attempt)
+                if not should_retry:
+                    return False
+                await asyncio.sleep(self._retry_backoff_seconds * attempt)
+                continue
+            except PermanentASRError as exc:
+                await self._mark_chunk_permanent_failure(chunk_id, str(exc))
+                return False
+            else:
+                await self._mark_chunk_completed(chunk_id, transcript)
+                return True
+
+    async def _prepare_chunk(self, chunk_id: int) -> dict | None:
+        async with AsyncSessionLocal() as session:
+            chunk = await session.get(AudioChunk, chunk_id)
+            if chunk is None:
+                return None
+            if chunk.status == ChunkStatus.COMPLETED:
+                return {"state": "completed"}
+            if chunk.status == ChunkStatus.PERMANENT_FAILURE:
+                return {"state": "failed"}
+            chunk.status = ChunkStatus.IN_PROGRESS
+            chunk.attempts += 1
+            chunk.last_error = None
+            chunk.updated_at = datetime.utcnow()
+            audio_path = chunk.audio_path
+            attempt = chunk.attempts
+            await session.commit()
+            return {"state": "processing", "audio_path": audio_path, "attempt": attempt}
+
+    async def _handle_transient_failure(self, chunk_id: int, error: str, attempt: int) -> bool:
+        async with AsyncSessionLocal() as session:
+            chunk = await session.get(AudioChunk, chunk_id)
+            if chunk is None:
+                return False
+            chunk.last_error = error
+            if attempt >= self._max_retries:
+                chunk.status = ChunkStatus.PERMANENT_FAILURE
+                chunk.updated_at = datetime.utcnow()
+                await session.commit()
+                return False
+            chunk.status = ChunkStatus.TRANSIENT_ERROR
+            chunk.updated_at = datetime.utcnow()
+            await session.commit()
+        return True
+
+    async def _mark_chunk_permanent_failure(self, chunk_id: int, error: str) -> None:
+        async with AsyncSessionLocal() as session:
+            chunk = await session.get(AudioChunk, chunk_id)
+            if chunk is None:
+                return
+            chunk.status = ChunkStatus.PERMANENT_FAILURE
+            chunk.last_error = error
+            chunk.updated_at = datetime.utcnow()
+            await session.commit()
+
+    async def _mark_chunk_completed(self, chunk_id: int, transcript: str) -> None:
+        async with AsyncSessionLocal() as session:
+            chunk = await session.get(AudioChunk, chunk_id, options=(selectinload(AudioChunk.job),))
+            if chunk is None:
+                return
+            chunk.status = ChunkStatus.COMPLETED
+            chunk.transcript_text = transcript
+            chunk.updated_at = datetime.utcnow()
+            chunk.job.updated_at = datetime.utcnow()
+            await session.commit()
+
+    async def _finalize_job(self, job_id: str, job_failed: bool) -> None:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(Job)
+                .options(selectinload(Job.chunks))
+                .where(Job.id == job_id)
+            )
+            job = result.scalar_one_or_none()
+            if job is None:
+                return
+            has_permanent_failure = any(
+                chunk.status == ChunkStatus.PERMANENT_FAILURE for chunk in job.chunks
+            )
+            all_completed = all(chunk.status == ChunkStatus.COMPLETED for chunk in job.chunks)
+            if has_permanent_failure or job_failed:
+                job.status = JobStatus.FAILED
+            elif all_completed:
+                job.status = JobStatus.COMPLETED
+            else:
+                job.status = JobStatus.IN_PROGRESS
+            transcripts = [chunk.transcript_text for chunk in job.chunks if chunk.transcript_text]
+            job.transcript_text = "\n".join(transcripts)
+            if job.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+                job.completed_at = datetime.utcnow()
+            job.updated_at = datetime.utcnow()
+            await session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.109.0
+uvicorn[standard]==0.24.0.post1
+SQLAlchemy==2.0.25
+aiosqlite==0.19.0


### PR DESCRIPTION
## Summary
- add FastAPI service with endpoints to create, query, and search transcription jobs
- persist job and chunk state in SQLite models and implement background worker with retry logic
- simulate ASR client with concurrency limits and add project documentation and dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0910c1208328a7185d300d53fda8