### PR TITLE
Add Dockerfile for Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.11
 
 # Disable output buffering and set up a working directory
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Disable output buffering and set up a working directory
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=8080
+
+WORKDIR /app
+
+# Install system dependencies (if any future build steps require gcc etc.).
+# Keeping this separate allows Docker to cache the layer when requirements don't change.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
+COPY app ./app
+
+# Expose the port Cloud Run listens on
+EXPOSE 8080
+
+# Run the FastAPI application with Uvicorn
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- add a Python 3.11-based Dockerfile that installs dependencies and runs the FastAPI app with Uvicorn

## Testing
- `docker build . -t test-image` *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf10ba914c8328b0c3068048524f59