### PR TITLE
Use Firestore for transcription persistence

### DIFF
--- a/audio-transcription/models.py
+++ b/audio-transcription/models.py
@@ -1,15 +1,6 @@
 from __future__ import annotations
 
 import enum
-from datetime import datetime
-from typing import List
-
-from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text
-from sqlalchemy.orm import Mapped, mapped_column, relationship
-
-from .database import Base
-
-
 class JobStatus(str, enum.Enum):
     QUEUED = "queued"
     IN_PROGRESS = "in_progress"
@@ -23,40 +14,3 @@ class ChunkStatus(str, enum.Enum):
     COMPLETED = "completed"
     TRANSIENT_ERROR = "transient_error"
     PERMANENT_FAILURE = "permanent_failure"
-
-
-class Job(Base):
-    __tablename__ = "jobs"
-
-    id: Mapped[str] = mapped_column(String, primary_key=True)
-    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
-    status: Mapped[JobStatus] = mapped_column(Enum(JobStatus), nullable=False, default=JobStatus.QUEUED)
-    transcript_text: Mapped[str] = mapped_column(Text, default="", nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
-    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-
-    chunks: Mapped[List[AudioChunk]] = relationship(
-        back_populates="job", order_by="AudioChunk.sequence", cascade="all, delete-orphan"
-    )
-
-
-class AudioChunk(Base):
-    __tablename__ = "audio_chunks"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False, index=True)
-    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
-    audio_path: Mapped[str] = mapped_column(String, nullable=False)
-    status: Mapped[ChunkStatus] = mapped_column(Enum(ChunkStatus), nullable=False, default=ChunkStatus.PENDING)
-    transcript_text: Mapped[str] = mapped_column(Text, default="", nullable=False)
-    attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
-
-    job: Mapped[Job] = relationship(back_populates="chunks")

--- a/audio-transcription/requirements.txt
+++ b/audio-transcription/requirements.txt
@@ -1,6 +1,5 @@
 fastapi==0.109.0
 uvicorn[standard]==0.24.0.post1
-SQLAlchemy==2.0.25
-aiosqlite==0.19.0
+google-cloud-firestore==2.13.1
 google-cloud-tasks==2.18.0
 google-cloud-logging==3.12.1


### PR DESCRIPTION
## Summary
- replace the SQLAlchemy configuration with a shared Firestore client targeting the `AudioTranscription` collection
- persist new transcription jobs to Firestore and read transcript data from Firestore for lookup and search endpoints
- adjust schemas and dependencies to reflect the Firestore-backed data model

## Testing
- python -m compileall audio-transcription

------
https://chatgpt.com/codex/tasks/task_e_68d07a03a7b883289d058092107a9a5b